### PR TITLE
fix: Checkbox and radiobox input false value handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,6 @@
 {
-  "lockfileVersion": 1
+  "name": "csv-paster",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
 }

--- a/package/csv-paster.js
+++ b/package/csv-paster.js
@@ -48,7 +48,6 @@ const getCurrentValue = (currElem) => {
 }
 
 function GetTruthyValue(value) {
-    console.log("Type", typeof value)
     if(typeof value === 'boolean') return value;
     else if(typeof value === 'number') return !(value === 0);
     else if(typeof value === 'undefined') return false;

--- a/package/csv-paster.js
+++ b/package/csv-paster.js
@@ -39,9 +39,26 @@ const getSerialized = (tableElem) => {
 
 const getCurrentValue = (currElem) => {
     const input = currElem.querySelector('input');
-    if (input) return input.value;
+    if (input) {
+        if(input.type === 'checkbox') return input.checked;
+        else return input.value;
+    }
     const selectElem = currElem.querySelector('select');
     if (selectElem) return selectElem.value;
+}
+
+function GetTruthyValue(value) {
+    console.log("Type", typeof value)
+    if(typeof value === 'boolean') return value;
+    else if(typeof value === 'number') return !(value === 0);
+    else if(typeof value === 'undefined') return false;
+    else if (typeof value === 'string') {
+        value = value.trim();
+        if(value.toLowerCase() === 'true') return true;
+        else if(value.toLowerCase() === 'false') return false;
+        else if(value === '0') return false;
+        else return true;
+    }
 }
 
 const setCurrentValue = (currentElem, data) => {
@@ -49,7 +66,7 @@ const setCurrentValue = (currentElem, data) => {
     inputElem = currentElem.querySelector('input');
     if (inputElem) {
         if (inputElem.type === 'checkbox' || inputElem.type === 'radio') {
-            [inputElem.checked, inputElem.value] = [!!data];
+            inputElem.checked = GetTruthyValue(data);
         } else {
             inputElem.value = data;
         }
@@ -114,7 +131,7 @@ async function fillInputs(ev, clipboardData, tableElem) {
         cells = Array.from(cells).filter(cell => !cell.classList.contains(classConstants.skipPaste));
         for (let cellIdx = 0; cellIdx < cells.length; cellIdx++) {
             const value = clipboardData[rowIdx][cellIdx];
-            if (!value) continue;
+            if(typeof value === "undefined") continue;
             setCurrentValue(cells[cellIdx], value);
         }
     }


### PR DESCRIPTION
This PR alters the handling of false values for checkbox and radio elements. If falsy values are provided and the element is checkbox or radiobox, the checked properties are updated as per the value.

### Input Data

45	1	PCS	20	45	1
1	1	CTN	20	45	1
2	2	DZN	20	45	0
3	3	half	20	45	1
4	1	kg	20	45	1

## Expectation

![image](https://github.com/BirajMainali/csv-paster/assets/28915667/12aa11ed-877b-46bd-a2dd-0f8e6a3615fb)


## Actual Output

![image](https://github.com/BirajMainali/csv-paster/assets/28915667/2f686b72-d2f9-463f-8498-b6b4ac7133d3)
